### PR TITLE
Pcollections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-#Records
+# Records
 
 Persistent, type safe, heterogeneous maps.
 
-Depends on [https://github.com/krukow/clj-ds](https://github.com/krukow/clj-ds) for persistent collections.
+Depends on [http://pcollections.org/](http://pcollections.org/) for persistent collections.
 
-##Usage
+Forked from [https://github.com/hansolaf/records](https://github.com/hansolaf/records) to change backing library.
+
+## Usage
 
 ```java
 // Specifying a datastructure
@@ -27,19 +29,17 @@ System.out.println(thing.equals(sameThing)); // Prints 'true'
 
 For more examples see RecordTest.
 
-##Motivation
+## Motivation
 
 This library is an attempt to make working with data structures in Java easier. This style of programming is heavily influenced by Clojure. It encourages the separation of data structures and functions that operate on them, and treats immutability as the default.
 
-####Code reuse
+#### Code reuse
 Normally, every class has to define constructors, accessors, hashCode, equals, toString, etc. This doesn't just require you to implement and maintain lots of code, but it leaves room for mistakes and differences in behaviour. By defining the way objects are constructed, printed, compared and accessed *once*, all records behave the same.
 
-Records implement java.util.Map, so every function that work on maps, also work on records. In addition, they allow you to either stream or iterate over their map entries. Records are functions of their keys, and a keys are functions of records.
+Records implement java.util.Map, so every function that work on maps, also work on records. In addition, they allow you to either stream or iterate over their map entries. Records are functions of their keys, and keys are functions of records.
 
-####Immutability
-Although Java allows marking variables as final, it doesn't solve the problem of composite immutable objects. Records use Clojure's persistent data structures (via krukow's port clj-ds) as a backing data structure to achieve fast and immutable composite objects. 
+#### Immutability
+Although Java allows marking variables as final, it doesn't solve the problem of composite immutable objects. Records use persistent data structures as a backing data structure to achieve fast and immutable composite objects.
 
-If you for some reason need a mutable record, you can convert records back and forth via the asMutable() and asImmutable() methods.
-
-##Runtime type safety
+## Runtime type safety
 At the moment, records provide no runtime guarantees for its contents. Just like any of the java collections, if you cast it to its raw type you can insert anything and it will only fail with a ClassCastException when you try to get data out of it expecting a certain type. 

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.krukow</groupId>
-            <artifactId>clj-ds</artifactId>
-            <version>0.0.4</version>
+            <groupId>org.pcollections</groupId>
+            <artifactId>pcollections</artifactId>
+            <version>2.1.2</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -43,6 +43,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/src/test/java/com/github/hansolaf/records/RecordTest.java
+++ b/src/test/java/com/github/hansolaf/records/RecordTest.java
@@ -19,9 +19,9 @@ public class RecordTest {
         Key<Double> price = Key.create("price");
     }
 
-    private Rec<Thing> a1 = new Rec<Thing>(name, "Some", price, 24.4d);
+    private Rec<Thing> a1 = new Rec<>(name, "Some", price, 24.4d);
     private Rec<Thing> a2 = Rec.create(name, "Some", price, 24.4d);
-    private Rec<Thing> b = new Rec<Thing>(name, "Other", price, 21.0d);
+    private Rec<Thing> b = new Rec<>(name, "Other", price, 21.0d);
 
     @Test
     public void supportEquals() {
@@ -53,7 +53,7 @@ public class RecordTest {
         map.put(name, "S");
         map.put(price, 1d);
         Rec<Thing> s1 = new Rec<>(map);
-        Rec<Thing> s2 = new Rec<Thing>(name, "S", price, 1d);
+        Rec<Thing> s2 = new Rec<>(name, "S", price, 1d);
         Rec<Thing> s3 = new Rec<Thing>().with(name, "S").with(price, 1d);
 
         assertEquals(1, new HashSet<>(Arrays.asList(s1, s2, s3)).size());


### PR DESCRIPTION
Change backing library to PCollections, which is actively maintained (as opposed to clj-ds). Also the footprint of PCollections is much smaller than clj-ds.
